### PR TITLE
Add Docker Compose Setup to CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker Compose
+        run: |
+          curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
       - name: Start Docker Compose environment
         run: docker-compose up -d
 


### PR DESCRIPTION
### PR Summary

**Add Docker Compose setup step in CI workflow;**

- Introduced a step to install Docker Compose in the GitHub Actions CI workflow to ensure it's available for the pipeline.
- Updated the workflow to check out the repository, set up Docker Compose, start the environment, wait for PostgreSQL readiness, run migrations, execute tests, and then shut down the environment.