### PR TITLE
Add SECRET_KEY for CI environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,6 @@ jobs:
       - name: Run Tests
         env:
           DJANGO_SETTINGS_MODULE: imdb_clone.test_settings
+          SECRET_KEY: django-test-key-123-for-ci
         run: |
           python manage.py test


### PR DESCRIPTION
### **PR Summary**

**Add SECRET_KEY for CI environment**

- Add test environment SECRET_KEY to GitHub Actions workflow
- Fix Django ImproperlyConfigured error in CI pipeline
- Use a simple key for testing purposes